### PR TITLE
Removing dead link and adding services to footer

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -3,6 +3,7 @@
 <a class="page-link" href="{{ "/blog" | prepend: site.baseurl }}">Blog</a>
 <a class="page-link" href="{{ "/ctf101" | prepend: site.baseurl }}">CTF 101</a>
 <a class="page-link" href="{{ "/sponsor" | prepend: site.baseurl }}">Sponsorship</a>
-<a class="page-link" href="https://sectalks.spreadshirt.com.au" title="Get your SecTalks Tshirt">Tshirt</a>
 <a class="page-link" href="https://github.com/sectalks/sectalks" title="Presentations and CTF archive">Archive</a>
+<a class="page-link" href="https://cyberchef.sectalks.org" title="CyberChef">CyberChef</a>
+<a class="page-link" href="https://yopass.sectalks.org" title="Yopass">Yopass</a>
 <a class="page-link" href="{{ "/coc" | prepend: site.baseurl }}" title="SecTalks Code of Conduct">no bullshit!</a>

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -4,6 +4,7 @@
 <a class="page-link" href="{{ "/ctf101" | prepend: site.baseurl }}">CTF 101</a>
 <a class="page-link" href="{{ "/sponsor" | prepend: site.baseurl }}">Sponsorship</a>
 <a class="page-link" href="https://github.com/sectalks/sectalks" title="Presentations and CTF archive">Archive</a>
+<a class="page-link" href="https://sectalks.myspreadshop.com.au/" title="Get your SecTalks Tshirt">Tshirt</a>
 <a class="page-link" href="https://cyberchef.sectalks.org" title="CyberChef">CyberChef</a>
 <a class="page-link" href="https://yopass.sectalks.org" title="Yopass">Yopass</a>
 <a class="page-link" href="{{ "/coc" | prepend: site.baseurl }}" title="SecTalks Code of Conduct">no bullshit!</a>


### PR DESCRIPTION
- Removing footer link pointing to spreadshirt.
- Adding links pointing to the Sectalks Cyberchef and Yopass instances.